### PR TITLE
Upgrade java-common to 0.13.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,1 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+ext {
+    junitVersion = "4.12"
+    androidSupportVersion = "23.0.0"
+    openTracingVersion = "0.30.0"
+}

--- a/examples/android-demo/build.gradle
+++ b/examples/android-demo/build.gradle
@@ -69,7 +69,7 @@ repositories {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile "com.android.support:appcompat-v7:${androidSupportVersion}"
-    compile "com.android.support:design:23.0.0"
+    compile "com.android.support:design:${androidSupportVersion}"
     compile 'com.android.volley:volley:1.0.0'
     compile "io.opentracing:opentracing-api:${openTracingVersion}"
     compile "io.opentracing:opentracing-util:${openTracingVersion}"

--- a/examples/android-demo/build.gradle
+++ b/examples/android-demo/build.gradle
@@ -9,6 +9,7 @@ buildscript {
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+
     }
 }
 
@@ -67,16 +68,17 @@ repositories {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.0.0'
-    compile 'com.android.support:design:23.0.0'
+    compile "com.android.support:appcompat-v7:${androidSupportVersion}"
+    compile "com.android.support:design:23.0.0"
     compile 'com.android.volley:volley:1.0.0'
-    compile 'io.opentracing:opentracing-api:0.30.0'
-    compile 'io.opentracing:opentracing-util:0.30.0'
+    compile "io.opentracing:opentracing-api:${openTracingVersion}"
+    compile "io.opentracing:opentracing-util:${openTracingVersion}"
 
     // vvv INCLUDE FOR BUILDS FROM LOCAL SOURCE
     compile(project(":lightstep-tracer-android")) {
         // Not needed on Android
         exclude module: 'httpclient'
+        exclude group: 'com.google.guava'
     }
     // ^^^ INCLUDE FOR BUILDS FROM LOCAL SOURCE
 

--- a/examples/android-simple/build.gradle
+++ b/examples/android-simple/build.gradle
@@ -42,8 +42,11 @@ repositories {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.3.0'
-    compile 'com.android.support:design:23.3.0'
-    compile project(':lightstep-tracer-android')
+    testCompile "junit:junit:${junitVersion}"
+    compile "com.android.support:appcompat-v7:${androidSupportVersion}"
+    compile "com.android.support:design:${androidSupportVersion}"
+    compile(project(":lightstep-tracer-android")) {
+        exclude module: 'httpclient'
+        exclude group: 'com.google.guava'
+    }
 }

--- a/lightstep-tracer-android/build.gradle
+++ b/lightstep-tracer-android/build.gradle
@@ -128,8 +128,8 @@ repositories {
 }
 
 dependencies {
-    compile 'com.lightstep.tracer:java-common:0.12.7'
-    compile 'io.grpc:grpc-okhttp:1.2.0'
+    compile 'com.lightstep.tracer:java-common:0.13.0'
+    compile 'io.grpc:grpc-okhttp:1.4.0'
 }
 
 task sourcesJar(type: Jar) {

--- a/lightstep-tracer-android/lint.xml
+++ b/lightstep-tracer-android/lint.xml
@@ -2,5 +2,6 @@
     <issue id="InvalidPackage">
         <ignore path="**/libthrift*.jar"/>
         <ignore regexp="okio.*jar" />
+        <ignore regexp="javax.naming"/>
     </issue>
 </lint>


### PR DESCRIPTION
Also upgraded io.grpc to 1.4.0 which necessitated adding javax.naming
to the lint ignore. See: https://github.com/grpc/grpc-java/releases/tag/v1.4.0

These changes put the example projects over the dex method count
limit, so I also added guava to the list of excluded dependencies
which brings us in under the limit.